### PR TITLE
feat(codex): walking skeleton — installable Codex plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "shipyard",
+  "interface": {
+    "displayName": "Shipyard"
+  },
+  "plugins": [
+    {
+      "name": "shipyard",
+      "source": {
+        "source": "local",
+        "path": "./plugins/shipyard"
+      },
+      "policy": {
+        "installation": "AVAILABLE"
+      },
+      "category": "Engineering"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "shipyard",
-      "version": "4.7.0",
+      "version": "4.8.0",
       "description": "Ship software systematically: project lifecycle, TDD, parallel agents, code review, security auditing, and infrastructure validation",
       "source": "./",
       "category": "development"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "description": "Ship software systematically: project lifecycle, TDD, parallel agents, code review, security auditing, and infrastructure validation",
   "author": {
     "name": "lgbarn",

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,12 @@
 *.sh text eol=lf
 *.bats text eol=lf
 *.bash text eol=lf
+
+# Generated Codex tree must stay LF so the drift guard (check-codex-sync.sh)
+# matches the generator's jq output on every platform. Without this, Windows
+# checks out the committed JSON as CRLF while jq regenerates LF, causing a
+# spurious drift failure. Skill sources are byte-copied into the tree, so pin
+# them too.
+skills/**/*.md text eol=lf
+plugins/** text eol=lf
+.agents/** text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Check version sync across files
         run: bash scripts/check-versions.sh
 
+      - name: Check Codex tree in sync with generator
+        run: bash scripts/check-codex-sync.sh
+
   release:
     name: Tag & Release
     runs-on: ubuntu-latest

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
-# Pre-commit hook: catch version mismatches and test failures before committing
-bash scripts/check-versions.sh && npm test
+# Pre-commit hook: catch version mismatches, Codex tree drift, and test failures before committing
+bash scripts/check-versions.sh && bash scripts/check-codex-sync.sh && npm test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,81 @@
+# Shipyard
+
+Agent-driven plugin (v4.8.0) for structured project execution: idea → brainstorm → plan → build → ship.
+
+Shipyard is authored as a **Claude Code plugin** (canonical source) and also ships a
+**generated Codex plugin tree** so Codex users can install it natively. The Claude Code
+artifacts are the single source of truth; the Codex tree is a build output (see
+"Codex support" below).
+
+## Commands
+
+```bash
+npm test                  # Full BATS test suite
+npm run test:fast         # Unit tests only (bats --filter-tags unit)
+npm run test:ci           # Parallel execution (4 jobs)
+bash scripts/check-versions.sh   # Verify version sync across files
+bash scripts/build-codex.sh      # Regenerate the Codex plugin tree from canonical artifacts
+bash scripts/check-codex-sync.sh # Verify the committed Codex tree matches the generator
+shellcheck --severity=warning scripts/*.sh hooks/*.sh test/run.sh
+```
+
+## Architecture
+
+```
+commands/       Slash commands (markdown + YAML frontmatter) — Claude Code
+skills/         Auto-activating skills (skills/<name>/SKILL.md) — shared with Codex
+agents/         Specialized subagents (markdown + YAML frontmatter) — Claude Code
+scripts/        State management, version checks, Codex generator, cleanup utilities
+hooks/          Plugin lifecycle hooks (SessionStart, TeammateIdle, TaskCompleted, Stop) — Claude Code
+test/           BATS test suite + test_helper.bash
+docs/           Protocols, guides, state schema, context engineering
+.claude-plugin/ Claude Code plugin metadata (plugin.json, marketplace.json) — canonical
+plugins/        Generated Codex plugin tree (plugins/shipyard/.codex-plugin/, skills/)
+.agents/        Generated Codex marketplace manifest (.agents/plugins/marketplace.json)
+.husky/         Pre-commit: check-versions.sh && check-codex-sync.sh && npm test
+```
+
+## Codex support
+
+Codex artifacts are **generated** from the canonical Claude Code artifacts — never hand-edited.
+
+- `scripts/build-codex.sh` transforms `.claude-plugin/plugin.json` + `skills/` into the Codex
+  tree under `plugins/shipyard/` and `.agents/plugins/marketplace.json`.
+- `scripts/check-codex-sync.sh` regenerates into a temp dir and diffs against the committed
+  tree; any drift fails CI. This is what keeps the Codex tree from drifting by hand.
+- Codex install: `codex plugin marketplace add lgbarn/shipyard`, then enable the plugin.
+- Codex support is **best-effort, not parity**: skills run natively, but parallel subagent
+  dispatch and lifecycle hooks degrade (see the PRD and the "Using Shipyard with Codex" guide).
+
+## Version Sync
+
+Six version strings must match. `scripts/check-versions.sh` enforces this (also runs in the
+pre-commit hook and CI).
+
+- `package.json`
+- `package-lock.json` (root + `packages[""]`)
+- `.claude-plugin/plugin.json`
+- `.claude-plugin/marketplace.json` (top entry)
+- `plugins/shipyard/.codex-plugin/plugin.json` (generated — regenerate after a version bump)
+- `CHANGELOG.md` (top entry)
+
+## Conventions
+
+- **Files/dirs:** kebab-case
+- **Commits:** conventional format — `feat:`, `fix:`, `chore:`, `build:`, `shipyard(phase-N):`
+- **Bash scripts:** `set -euo pipefail`, ShellCheck compliant (`--severity=warning`)
+- **Skills:** auto-discovered from `skills/*/SKILL.md` — no manual registration
+- **Agents:** model values are `opus`, `sonnet`, `haiku`, or `inherit`
+- **Codex tree:** never edit `plugins/` or `.agents/` by hand — run `scripts/build-codex.sh`
+- **Adding components:** see [CONTRIBUTING.md](CONTRIBUTING.md)
+
+## Gotchas
+
+- **Pre-commit hook** runs `check-versions.sh && check-codex-sync.sh && npm test` — all must pass
+- **`.shipyard/` is gitignored** — local project state only, never committed
+- **jq >= 1.6 required** — `state-read.sh` exits code 3 if missing; the Codex generator also needs jq
+- **Symlinked `.shipyard/`** is rejected (prevents writes outside project)
+- **Team locking** uses directory-based locks at `${TMPDIR}/shipyard-state-${hash}.lock`
+- **CI matrix** tests on macOS, Ubuntu, and Windows (WSL); ShellCheck + version + Codex-sync checks run on Ubuntu only
+- **PR version bump enforced** — CI rejects PRs where package.json version <= main branch version
+- **After a version bump** regenerate the Codex tree (`bash scripts/build-codex.sh`) or `check-codex-sync.sh` will fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [4.8.0] - 2026-06-19
+
+### Added
+- **Codex support (walking skeleton)**: Shipyard can now be installed under Codex CLI via `codex plugin marketplace add lgbarn/shipyard`. Best-effort, not parity — skills run natively; parallel agents and lifecycle hooks degrade (tracked in #14).
+- **Codex tree generator** (`scripts/build-codex.sh`): generates the Codex plugin tree (`plugins/shipyard/`, `.agents/plugins/marketplace.json`) from the canonical Claude Code artifacts. Currently emits the `using-shipyard` skill as the proof-of-pipeline skill; later slices fan out the rest.
+- **Codex drift guard** (`scripts/check-codex-sync.sh`): fails CI when the committed Codex tree differs from the generator output, keeping the Claude artifacts the single source of truth.
+- **Corrected `AGENTS.md`**: Codex-facing repo-development guide (replaces a broken find/replace artifact).
+
+### Changed
+- **Version sync now covers 6 files**: `check-versions.sh` also verifies the generated `plugins/shipyard/.codex-plugin/plugin.json`.
+- **Pre-commit and CI** now run `check-codex-sync.sh` alongside the version check and tests.
+
 ## [4.7.0] - 2026-04-06
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lgbarn/shipyard",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lgbarn/shipyard",
-      "version": "4.7.0",
+      "version": "4.8.0",
       "license": "MIT",
       "devDependencies": {
         "bats": "^1.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lgbarn/shipyard",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "description": "Ship software systematically: project lifecycle, TDD, parallel agents, code review, security auditing, and infrastructure validation — from idea to production",
   "keywords": [
     "claude-code-plugin",

--- a/plugins/shipyard/.codex-plugin/plugin.json
+++ b/plugins/shipyard/.codex-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "shipyard",
+  "version": "4.8.0",
+  "description": "Ship software systematically: project lifecycle, TDD, parallel agents, code review, security auditing, and infrastructure validation",
+  "author": {
+    "name": "lgbarn",
+    "email": "lgbarn@users.noreply.github.com"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Shipyard",
+    "shortDescription": "Ship software systematically with Codex",
+    "category": "Engineering",
+    "defaultPrompt": [
+      "Help me ship this feature systematically",
+      "What should I do next in Shipyard?"
+    ]
+  }
+}

--- a/plugins/shipyard/skills/using-shipyard/SKILL.md
+++ b/plugins/shipyard/skills/using-shipyard/SKILL.md
@@ -1,0 +1,279 @@
+---
+name: using-shipyard
+description: Use when starting any conversation, when the user asks "what should I do", "help me", "how do I use shipyard", or "where do I start". Establishes how to find and use skills, requiring Skill tool invocation before ANY response including clarifying questions. Also use when unsure which skill or command applies to the current situation.
+---
+
+<!-- TOKEN BUDGET: 220 lines / ~660 tokens -->
+
+# Using Shipyard
+
+## What is Shipyard?
+
+Shipyard is a structured project execution framework for Claude Code. It works as a plugin that helps you:
+
+- **Plan work in phases** — break large projects into manageable pieces with clear success criteria
+- **Build with parallel agents and TDD** — fresh 200k-token context per task, atomic commits, test-driven development
+- **Review code quality and security automatically** — two-stage code review, OWASP security audits, complexity analysis
+- **Ship with confidence** — verification gates, documentation generation, and delivery workflows
+
+Shipyard works as a Claude Code plugin. Install it once, then use slash commands in any project.
+
+## Getting Started
+
+New to Shipyard? Follow these steps:
+
+1. **`/shipyard:init`** — Set up your project preferences (interaction mode, git strategy, quality gates). Takes ~1 minute.
+2. **`/shipyard:brainstorm`** — Explore what you want to build through interactive dialogue. Captures a project definition.
+3. **`/shipyard:plan 1`** — Plan your first phase of work. Researches the codebase and decomposes into executable tasks.
+4. **`/shipyard:build`** — Execute the plan with parallel builder agents, review gates, and security audits.
+5. **`/shipyard:ship`** — Verify, audit, document, and deliver your completed work.
+
+For quick one-off tasks, skip the lifecycle and use `/shipyard:quick 'description'`.
+
+## I Want To...
+
+| Goal | Command |
+|------|---------|
+| Set up a new project | `/shipyard:init` |
+| Explore requirements | `/shipyard:brainstorm` |
+| Understand existing code | `/shipyard:map` |
+| Plan a phase | `/shipyard:plan [phase] [--skip-research]` |
+| Build from a plan | `/shipyard:build [phase] [--plan N] [--light]` |
+| Quick one-off task | `/shipyard:quick "task"` |
+| Review my code | `/shipyard:review` |
+| Security check | `/shipyard:audit` |
+| Research technology options | `/shipyard:research "topic"` |
+| Find duplication/complexity | `/shipyard:simplify [scope]` |
+| Generate documentation | `/shipyard:document [scope]` |
+| Run tests and verify | `/shipyard:verify [criteria]` |
+| Check progress | `/shipyard:status` |
+| Change settings | `/shipyard:settings` |
+| Rollback to checkpoint | `/shipyard:rollback` |
+| Recover from errors | `/shipyard:recover` |
+| Ship completed work | `/shipyard:ship [--phase \| --milestone \| --branch]` |
+
+## How to Access Skills
+
+**In Claude Code:** Use the `Skill` tool. When you invoke a skill, its content is loaded and presented to you — follow it directly. Never use the Read tool on skill files.
+
+**In other environments:** Check your platform's documentation for how skills are loaded.
+
+## Available Skills
+
+Shipyard provides 19 skills. Skills are **behavioral disciplines** — they define HOW to do work, not what to build.
+
+| Skill | What It Actually Does |
+|-------|----------------------|
+| `shipyard:using-shipyard` | Index of all skills/commands with triggers and activation rules (this skill) |
+| `shipyard:shipyard-tdd` | Enforces write-failing-test → watch-fail → implement → watch-pass → refactor cycle. Tests written after code prove nothing. |
+| `shipyard:shipyard-debugging` | 4-phase investigation (root cause → pattern analysis → hypothesis test → fix). After 3 failed fixes, stop and question architecture. |
+| `shipyard:shipyard-verification` | Blocks "done"/"fixed"/"passing" claims until you run the actual command fresh and read the output. Evidence before assertions. |
+| `shipyard:shipyard-brainstorming` | One-question-at-a-time Socratic dialogue to turn vague ideas into validated designs with trade-offs before any code is written. |
+| `shipyard:security-audit` | Checks OWASP Top 10, scans for hardcoded secrets, audits dependencies and IaC (Terraform/Ansible/Docker). Critical findings block merge. |
+| `shipyard:code-simplification` | Post-implementation review for duplication (3+ occurrences → extract), dead code, over-engineering, and AI bloat patterns. |
+| `shipyard:infrastructure-validation` | Tool-chain workflows for Terraform (fmt/validate/plan/lint), Ansible (lint/syntax/dry-run), Docker (hadolint/build/trivy). |
+| `shipyard:parallel-dispatch` | Routes 2+ independent tasks to concurrent agents with isolated scope/constraints. Prevents sequential bottleneck. |
+| `shipyard:shipyard-writing-plans` | Converts specs into executable tasks with exact file paths, code samples, verification commands, and TDD steps for builder handoff. |
+| `shipyard:shipyard-executing-plans` | Runs fresh builder agent per task + two-stage review (spec compliance then code quality) + security audit + simplification gate. |
+| `shipyard:git-workflow` | Full branch lifecycle: create worktree → setup → baseline tests → work → verify → 4 completion options (merge/PR/keep/discard). |
+| `shipyard:documentation` | Generates code comments, API docs (params/returns/examples), architecture docs, and user guides. Verifies examples actually work. |
+| `shipyard:shipyard-writing-skills` | TDD for docs: run scenario WITHOUT skill (RED) → document agent rationalizations → write skill countering them (GREEN) → refine. |
+| `shipyard:shipyard-testing` | Enforces behavior-based testing via public APIs: AAA structure, DAMP not DRY, name tests after behavior, prefer state over mocks. |
+| `shipyard:lessons-learned` | After phase completion, captures what worked/surprised/failed into `.shipyard/LESSONS.md` and optionally feeds back to CLAUDE.md. |
+| `shipyard:shipyard-handoff` | Captures session context into `.shipyard/HANDOFF.md` so the next session can resume without losing progress. |
+| `shipyard:import-spec` | Imports a spec-kit feature directory into Shipyard, replacing brainstorming. Maps spec artifacts to PROJECT.md and ROADMAP.md. |
+| `shipyard:import-spec-file` | Imports a handwritten spec document into Shipyard, replacing brainstorming. Interviews to fill gaps via Socratic dialogue. |
+
+## Shipyard Commands
+
+Commands are **actions** — they produce artifacts, change state, or trigger workflows.
+
+### Lifecycle Commands (run in order for full projects)
+
+| Command | What It Actually Does |
+|---------|----------------------|
+| `/shipyard:init` | **Settings only.** Asks ~9 preference questions (interaction mode, git strategy, review depth, quality gates, model routing) and writes `.shipyard/config.json`. No codebase analysis or planning. |
+| `/shipyard:brainstorm` | Socratic dialogue exploring goals/constraints → writes `.shipyard/PROJECT.md`. Optionally dispatches architect to generate `ROADMAP.md` with up to 3 revision cycles. |
+| `/shipyard:plan [phase] [--skip-research]` | Dispatches researcher → architect → verifier agents to create executable plan files (`PLAN-W.P.md`) with tasks, file paths, verification commands. Produces `RESEARCH.md` and context files. |
+| `/shipyard:build [phase] [--plan N] [--light]` | Dispatches builder agent per plan + two-stage review + optional security audit/simplification/docs. Handles retries (up to 2) on critical issues. Produces `SUMMARY` and `REVIEW` files per plan. |
+| `/shipyard:ship [--phase \| --milestone \| --branch]` | Pre-ship verification + tests + security audit + docs + lessons learned capture. Then presents 4 delivery options: merge locally, push PR, preserve branch, or discard. Archives artifacts. |
+
+### Session Management
+
+| Command | What It Actually Does |
+|---------|----------------------|
+| `/shipyard:status` | Reads state files and displays progress dashboard with blockers and next-action suggestion. No side effects. |
+| `/shipyard:resume` | Reconstructs context from `STATE.json` + `HISTORY.md` + artifacts to detect interrupted work and route to recovery. |
+| `/shipyard:settings` | Interactive menu to view/update `.shipyard/config.json` preferences. Supports `list`, `view <key>`, `set <key> <value>`. |
+| `/shipyard:issues` | Manages deferred issues in `.shipyard/ISSUES.md` with severity tracking. Supports `--add`, `--resolve`, `--list`. |
+| `/shipyard:rollback` | Reverts to a git checkpoint (state-only or full code+state). Lists recent checkpoints, creates safety checkpoint before reverting. |
+| `/shipyard:recover` | Diagnoses state inconsistencies and offers recovery: resume, rollback, rebuild state from artifacts, or full reset. |
+
+### On-Demand Tools (use anytime, no lifecycle required)
+
+| Command | What It Actually Does |
+|---------|----------------------|
+| `/shipyard:quick "task"` | Dispatches architect (simplified plan) → builder (execute + verify) for small self-contained tasks. Produces `QUICK-NNN.md`. No roadmap needed. |
+| `/shipyard:review [target]` | Two-stage code review (spec compliance if plan exists, otherwise quality). Accepts uncommitted changes, diff ranges, file paths, or branch comparisons. |
+| `/shipyard:audit [scope]` | OWASP Top 10 + secrets + dependencies + IaC security scan. Critical findings are hard gates. Accepts changes, ranges, directories, or full codebase. |
+| `/shipyard:simplify [scope]` | Detects duplication, dead code, unnecessary abstractions, and AI bloat. Non-blocking findings. Accepts changes, ranges, or directories. |
+| `/shipyard:document [scope]` | Generates API docs, architecture updates, user guides. Analyzes code vs existing docs to find gaps. Accepts changes, ranges, or directories. |
+| `/shipyard:research <topic>` | Dispatches researcher to evaluate technology options via web search + codebase analysis. Produces comparison matrix with recommendations. |
+| `/shipyard:verify [criteria]` | Runs acceptance criteria or test suites, records PASS/FAIL with evidence. Accepts test suite, criteria file, phase number, or inline text. |
+| `/shipyard:debug <error>` | Dispatches debugger agent for systematic root-cause analysis using 5 Whys protocol. Accepts error descriptions or test names. |
+| `/shipyard:map [focus]` | Deep codebase analysis producing up to 7 docs (STACK, INTEGRATIONS, ARCHITECTURE, STRUCTURE, CONVENTIONS, TESTING, CONCERNS). Supports parallel "all" mode. |
+| `/shipyard:worktree` | Git worktree management: `create` (isolated branch + setup + tests), `list`, `switch`, `remove` (with dirty-state safety checks). |
+| `/shipyard:move-docs` | Relocates codebase docs between `.shipyard/codebase/` (private) and `docs/codebase/` (public) using `git mv`. |
+
+<activation>
+
+## Skill Activation Protocol
+
+When a trigger condition matches, invoke the corresponding skill before responding.
+
+### File Pattern Triggers
+| Pattern | Skill |
+|---------|-------|
+| `*.tf`, `*.tfvars`, `terraform*` | `shipyard:infrastructure-validation` |
+| `Dockerfile`, `docker-compose.yml`, `*.dockerfile` | `shipyard:infrastructure-validation` |
+| `playbook*.yml`, `roles/`, `inventory/`, `ansible*` | `shipyard:infrastructure-validation` |
+| `*.test.*`, `*.spec.*`, `__tests__/`, `*_test.go` | `shipyard:shipyard-tdd` |
+
+### Task Marker Triggers
+| Marker | Skill |
+|--------|-------|
+| `tdd="true"` in plan task | `shipyard:shipyard-tdd` |
+| Plan file loaded for execution | `shipyard:shipyard-executing-plans` |
+| Design discussion, feature exploration | `shipyard:shipyard-brainstorming` |
+| Creating an implementation plan | `shipyard:shipyard-writing-plans` |
+
+### State Condition Triggers
+| Condition | Skill |
+|-----------|-------|
+| About to claim "done", "complete", "fixed" | `shipyard:shipyard-verification` |
+| About to commit, create PR, or merge | `shipyard:shipyard-verification` |
+| Bug, error, test failure, unexpected behavior | `shipyard:shipyard-debugging` |
+| 2+ independent tasks with no shared state | `shipyard:parallel-dispatch` |
+| Creating or editing a skill file | `shipyard:shipyard-writing-skills` |
+| Branch management, delivery, worktrees | `shipyard:git-workflow` |
+| Starting feature work on a new phase | `shipyard:git-workflow` |
+| `SHIPYARD_IS_TEAMMATE=true` in env | `shipyard:shipyard-executing-plans`, `shipyard:shipyard-verification` — follow teammate mode sections |
+
+### Content Pattern Triggers
+| Pattern in output or conversation | Skill |
+|----------------------------------|-------|
+| Error, exception, traceback, failure | `shipyard:shipyard-debugging` |
+| Security, vulnerability, CVE, OWASP | `shipyard:security-audit` |
+| Duplicate, complex, bloat, refactor | `shipyard:code-simplification` |
+| Document, README, API docs, changelog | `shipyard:documentation` |
+
+### Natural Language Triggers
+| Phrase | Skill |
+|--------|-------|
+| "what should I do", "help me", "how do I", "where do I start" | `shipyard:using-shipyard` |
+| "build this", "implement this", "execute the plan" | `shipyard:shipyard-executing-plans` |
+| "fix this bug", "why is this failing", "debug this", "it's broken" | `shipyard:shipyard-debugging` |
+| "test first", "write tests", "TDD", "red green refactor" | `shipyard:shipyard-tdd` |
+| "I want to add", "let's design", "brainstorm", "what if we" | `shipyard:shipyard-brainstorming` |
+| "is this done", "verify this", "check my work" | `shipyard:shipyard-verification` |
+| "add tests", "test coverage", "testing strategy" | `shipyard:shipyard-testing` |
+| "security check", "is this secure", "vulnerability scan" | `shipyard:security-audit` |
+| "simplify this", "clean up", "too complex" | `shipyard:code-simplification` |
+| "document this", "write docs", "update README" | `shipyard:documentation` |
+| "create branch", "commit this", "merge branch", "start feature" | `shipyard:git-workflow` |
+| "what did we learn", "capture lessons", "retrospective" | `shipyard:lessons-learned` |
+| "validate terraform", "check docker", "lint ansible" | `shipyard:infrastructure-validation` |
+| "run in parallel", "do these at the same time" | `shipyard:parallel-dispatch` |
+| "write a plan", "create a plan", "plan this feature" | `shipyard:shipyard-writing-plans` |
+| "create a skill", "write a skill", "new skill" | `shipyard:shipyard-writing-skills` |
+| "handoff", "hand off", "transfer session", "save context", "I'm done for now" | `shipyard:shipyard-handoff` |
+| "import spec", "import my spec", "use this spec" | `shipyard:import-spec`, `shipyard:import-spec-file` |
+
+</activation>
+
+<instructions>
+
+## The Core Rule
+
+Invoke relevant skills BEFORE any response or action. If there is a reasonable chance a skill applies, invoke it to check. If an invoked skill turns out to be wrong for the situation, you don't need to use it.
+
+Before every response, evaluate triggers in this order:
+1. **File patterns** — check files being discussed, modified, or created
+2. **Task markers** — check any loaded plans or task definitions
+3. **State conditions** — check current workflow state and intent
+4. **Content patterns** — check recent output and user messages
+
+If any trigger matches, invoke the skill before responding. Multiple triggers can fire simultaneously.
+
+</instructions>
+
+<rules>
+
+## Conflict Resolution
+
+When multiple skills could activate for the same situation, follow this priority chain:
+
+1. **Debugging** (`shipyard-debugging`) — always investigate root cause before anything else
+2. **TDD** (`shipyard-tdd`) — if writing code, tests come first
+3. **Verification** (`shipyard-verification`) — before claiming anything is done
+4. **Brainstorming** (`shipyard-brainstorming`) — design before implementation
+5. **Security** (`security-audit`) — security concerns override feature work
+6. **All others** — apply in the order they match
+
+**Example:** User says "fix this bug and add tests" → debugging first (investigate), then TDD (write failing test), then verification (prove it works).
+
+## Red Flags
+
+These thoughts indicate a missed skill invocation:
+
+| Thought | What to do |
+|---------|------------|
+| "This is just a simple question" | Questions are tasks. Check for skills. |
+| "Let me explore the codebase first" | Skills tell you HOW to explore. Check first. |
+| "This doesn't need a formal skill" | If a skill exists for it, use it. |
+| "I'll just do this one thing first" | Check BEFORE doing anything. |
+
+## Skill Priority
+
+When multiple skills could apply: **process skills first** (brainstorming, debugging), then **implementation skills** (executing-plans, parallel-dispatch).
+
+## Skill Types
+
+**Rigid** (TDD, debugging, verification): Follow exactly. **Flexible** (patterns): Adapt to context. The skill itself tells you which.
+
+## User Instructions
+
+Instructions say WHAT, not HOW. "Add X" or "Fix Y" doesn't mean skip workflows.
+
+</rules>
+
+<examples>
+
+## Good: Skill invoked before responding
+
+User: "Add a health check endpoint"
+
+Before responding, check triggers:
+- Task marker → this is implementation → check for `shipyard:shipyard-tdd` (writing code)
+- State condition → starting feature work → check for `shipyard:git-workflow` (branch management)
+
+Result: Invoke `shipyard:shipyard-tdd`, then proceed with implementation using TDD discipline.
+
+## Bad: Skipping skill invocation
+
+User: "Add a health check endpoint"
+
+Immediately start writing code without checking triggers. Miss TDD discipline, skip branch creation, no verification before claiming done.
+
+## Good: Multiple triggers fire
+
+User: "Fix the SQL injection bug in the auth module"
+
+Triggers matched:
+1. Content pattern → "bug" → invoke `shipyard:shipyard-debugging` (investigate root cause first)
+2. Content pattern → "SQL injection" → invoke `shipyard:security-audit` (check for related vulnerabilities)
+3. State condition → will claim "fixed" when done → invoke `shipyard:shipyard-verification` (verify before claiming)
+
+Result: Debug first, audit for related issues, verify the fix works.
+
+</examples>

--- a/scripts/build-codex.sh
+++ b/scripts/build-codex.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Generate the Codex plugin tree from the canonical Claude Code artifacts.
+#
+# Shipyard's Claude Code plugin (.claude-plugin/, skills/) is the single source
+# of truth. This script transforms it into a Codex plugin tree:
+#
+#   .agents/plugins/marketplace.json          Codex marketplace manifest
+#   plugins/shipyard/.codex-plugin/plugin.json Codex plugin manifest
+#   plugins/shipyard/skills/<name>/SKILL.md    skills (copied byte-for-byte)
+#
+# The Codex tree is a COMMITTED build artifact. CI (check-codex-sync.sh) enforces
+# that the committed tree equals this generator's output, so the tree can never
+# drift from the canonical source by hand.
+#
+# Usage: build-codex.sh [OUTPUT_DIR]   (defaults to the repo root)
+#
+set -euo pipefail
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "Error: jq is required but not installed" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+OUT_DIR="${1:-${ROOT_DIR}}"
+
+SRC_PLUGIN="${ROOT_DIR}/.claude-plugin/plugin.json"
+PLUGIN_DIR="${OUT_DIR}/plugins/shipyard"
+CODEX_MANIFEST="${PLUGIN_DIR}/.codex-plugin/plugin.json"
+MARKETPLACE="${OUT_DIR}/.agents/plugins/marketplace.json"
+
+# Skills included in the walking skeleton (Slice 1). Later slices expand this set.
+SKELETON_SKILLS=("using-shipyard")
+
+NAME=$(jq -r '.name' "${SRC_PLUGIN}")
+
+# --- clean previous output so removals are reflected deterministically ---
+rm -rf "${PLUGIN_DIR}" "${OUT_DIR}/.agents"
+mkdir -p "${PLUGIN_DIR}/.codex-plugin" "${PLUGIN_DIR}/skills" "${OUT_DIR}/.agents/plugins"
+
+# --- plugin manifest: carry over name/version/description/author, then add the
+#     Codex-specific skills pointer and interface block ---
+jq '. + {
+      "skills": "./skills/",
+      "interface": {
+        "displayName": "Shipyard",
+        "shortDescription": "Ship software systematically with Codex",
+        "category": "Engineering",
+        "defaultPrompt": [
+          "Help me ship this feature systematically",
+          "What should I do next in Shipyard?"
+        ]
+      }
+    }' "${SRC_PLUGIN}" > "${CODEX_MANIFEST}"
+
+# --- marketplace manifest pointing at the plugin dir ---
+jq -n --arg name "${NAME}" '{
+      "name": $name,
+      "interface": { "displayName": "Shipyard" },
+      "plugins": [
+        {
+          "name": $name,
+          "source": { "source": "local", "path": "./plugins/shipyard" },
+          "policy": { "installation": "AVAILABLE" },
+          "category": "Engineering"
+        }
+      ]
+    }' > "${MARKETPLACE}"
+
+# --- copy skills byte-for-byte (Codex SKILL.md format is identical) ---
+for skill in "${SKELETON_SKILLS[@]}"; do
+    src="${ROOT_DIR}/skills/${skill}"
+    if [[ ! -f "${src}/SKILL.md" ]]; then
+        echo "Error: canonical skill not found: ${skill}" >&2
+        exit 1
+    fi
+    mkdir -p "${PLUGIN_DIR}/skills/${skill}"
+    cp "${src}/SKILL.md" "${PLUGIN_DIR}/skills/${skill}/SKILL.md"
+done
+
+echo "Generated Codex plugin tree at ${OUT_DIR} (${#SKELETON_SKILLS[@]} skill(s))"

--- a/scripts/check-codex-sync.sh
+++ b/scripts/check-codex-sync.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Verify the committed Codex plugin tree equals the generator's output.
+#
+# The Codex tree (plugins/shipyard/, .agents/plugins/marketplace.json) is a
+# build artifact produced by build-codex.sh. This guard regenerates it into a
+# temp dir and diffs it against the committed tree; any drift fails CI. This is
+# what makes "Claude artifacts are the single source of truth" enforceable
+# rather than aspirational.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+bash "${SCRIPT_DIR}/build-codex.sh" "${TMP_DIR}" >/dev/null
+
+DRIFT=0
+for rel in "plugins/shipyard" ".agents/plugins/marketplace.json"; do
+    if ! diff -r "${ROOT_DIR}/${rel}" "${TMP_DIR}/${rel}" >/dev/null 2>&1; then
+        echo "ERROR: Codex tree drift detected in ${rel}"
+        diff -r "${ROOT_DIR}/${rel}" "${TMP_DIR}/${rel}" || true
+        DRIFT=1
+    fi
+done
+
+if [[ ${DRIFT} -gt 0 ]]; then
+    echo ""
+    echo "Committed Codex tree differs from generator output."
+    echo "Regenerate with: bash scripts/build-codex.sh"
+    exit 1
+fi
+
+echo "Codex tree in sync with generator output"

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
 # Verify all version strings are in sync across the project.
-# Checks: package.json, package-lock.json (2 locations), plugin.json, marketplace.json
+# Checks: package.json, package-lock.json (2 locations), plugin.json, marketplace.json,
+#         and the generated Codex plugin manifest.
 #
 
 set -euo pipefail
@@ -19,6 +20,7 @@ LOCK_VERSION=$(jq -r '.version' "${ROOT_DIR}/package-lock.json")
 LOCK_PKG_VERSION=$(jq -r '.packages[""].version' "${ROOT_DIR}/package-lock.json")
 PLUGIN_VERSION=$(jq -r '.version' "${ROOT_DIR}/.claude-plugin/plugin.json")
 MKT_VERSION=$(jq -r '.plugins[0].version' "${ROOT_DIR}/.claude-plugin/marketplace.json")
+CODEX_PLUGIN_VERSION=$(jq -r '.version' "${ROOT_DIR}/plugins/shipyard/.codex-plugin/plugin.json")
 
 ERRORS=0
 
@@ -39,6 +41,11 @@ fi
 
 if [[ "${MKT_VERSION}" != "${PKG_VERSION}" ]]; then
     echo "ERROR: marketplace.json version (${MKT_VERSION}) != package.json (${PKG_VERSION})"
+    ERRORS=$((ERRORS + 1))
+fi
+
+if [[ "${CODEX_PLUGIN_VERSION}" != "${PKG_VERSION}" ]]; then
+    echo "ERROR: codex plugin.json version (${CODEX_PLUGIN_VERSION}) != package.json (${PKG_VERSION})"
     ERRORS=$((ERRORS + 1))
 fi
 

--- a/test/build-codex.bats
+++ b/test/build-codex.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+load test_helper
+
+BUILD_CODEX="${PROJECT_ROOT}/scripts/build-codex.sh"
+CHECK_SYNC="${PROJECT_ROOT}/scripts/check-codex-sync.sh"
+
+# bats test_tags=unit
+@test "build-codex: generates a valid Codex plugin manifest" {
+    run bash "$BUILD_CODEX" "${BATS_TEST_TMPDIR}"
+    assert_success
+
+    local manifest="${BATS_TEST_TMPDIR}/plugins/shipyard/.codex-plugin/plugin.json"
+    [ -f "$manifest" ]
+    run jq -e '.skills == "./skills/" and .interface.displayName == "Shipyard"' "$manifest"
+    assert_success
+}
+
+# bats test_tags=unit
+@test "build-codex: codex plugin version matches package.json" {
+    bash "$BUILD_CODEX" "${BATS_TEST_TMPDIR}"
+    local pkg gen
+    pkg=$(jq -r '.version' "${PROJECT_ROOT}/package.json")
+    gen=$(jq -r '.version' "${BATS_TEST_TMPDIR}/plugins/shipyard/.codex-plugin/plugin.json")
+    [ "$pkg" = "$gen" ]
+}
+
+# bats test_tags=unit
+@test "build-codex: marketplace path resolves to the plugin dir" {
+    bash "$BUILD_CODEX" "${BATS_TEST_TMPDIR}"
+    local path
+    path=$(jq -r '.plugins[0].source.path' "${BATS_TEST_TMPDIR}/.agents/plugins/marketplace.json")
+    [ -d "${BATS_TEST_TMPDIR}/${path}" ]
+    [ -f "${BATS_TEST_TMPDIR}/${path}/.codex-plugin/plugin.json" ]
+}
+
+# bats test_tags=unit
+@test "build-codex: copies the using-shipyard skill byte-for-byte" {
+    bash "$BUILD_CODEX" "${BATS_TEST_TMPDIR}"
+    run diff "${PROJECT_ROOT}/skills/using-shipyard/SKILL.md" \
+        "${BATS_TEST_TMPDIR}/plugins/shipyard/skills/using-shipyard/SKILL.md"
+    assert_success
+}
+
+# bats test_tags=unit
+@test "build-codex: committed Codex tree is in sync with generator output" {
+    run bash "$CHECK_SYNC"
+    assert_success
+    assert_output --partial "in sync"
+}

--- a/test/check-versions.bats
+++ b/test/check-versions.bats
@@ -10,6 +10,7 @@ setup_version_fixture() {
 
     mkdir -p "${root}/scripts"
     mkdir -p "${root}/.claude-plugin"
+    mkdir -p "${root}/plugins/shipyard/.codex-plugin"
 
     # Symlink the real script so SCRIPT_DIR resolves to our fake root/scripts
     cp "$CHECK_VERSIONS" "${root}/scripts/check-versions.sh"
@@ -32,6 +33,11 @@ EOF
     # marketplace.json
     cat > "${root}/.claude-plugin/marketplace.json" <<EOF
 {"plugins":[{"name":"test","version":"${version}"}]}
+EOF
+
+    # generated Codex plugin manifest
+    cat > "${root}/plugins/shipyard/.codex-plugin/plugin.json" <<EOF
+{"name":"test","version":"${version}"}
 EOF
 
     echo "$root"
@@ -111,6 +117,22 @@ EOF
     run bash "${root}/scripts/check-versions.sh"
     assert_failure
     assert_output --partial "marketplace.json version (7.7.7) != package.json (3.0.0)"
+}
+
+# --- codex plugin.json mismatch ---
+
+# bats test_tags=unit
+@test "check-versions: detects codex plugin.json version mismatch" {
+    local root
+    root=$(setup_version_fixture "3.0.0")
+
+    cat > "${root}/plugins/shipyard/.codex-plugin/plugin.json" <<'EOF'
+{"name":"test","version":"5.5.5"}
+EOF
+
+    run bash "${root}/scripts/check-versions.sh"
+    assert_failure
+    assert_output --partial "codex plugin.json version (5.5.5) != package.json (3.0.0)"
 }
 
 # --- Multiple mismatches ---


### PR DESCRIPTION
## Summary
- Adds **best-effort Codex support** (PRD #14, Slice 1): Shipyard installs under Codex CLI via `codex plugin marketplace add lgbarn/shipyard`.
- The Codex tree is **generated** from the canonical Claude Code artifacts (`scripts/build-codex.sh`) and committed as a build output — a drift guard (`scripts/check-codex-sync.sh`) fails CI if the committed tree ≠ generator output, so the single-source-of-truth is enforceable, not aspirational.
- Version sync extended to the generated codex `plugin.json` (6 files); pre-commit + CI lint job run the drift guard.
- Corrected `AGENTS.md` (replaces a broken find/replace artifact that referenced a non-existent `.Codex-plugin/` path).

## Closes
Closes #15

## Acceptance criteria
- [x] `build-codex.sh` generates `.codex-plugin/plugin.json`, `.agents/plugins/marketplace.json`, and a copied skill from canonical artifacts
- [x] Generated codex `plugin.json` is valid JSON with a `skills` pointer + `interface` block; version equals `package.json`
- [x] Generated `marketplace.json` is valid and its `plugins[].source.path` resolves to the plugin dir
- [x] `codex plugin marketplace add <local repo>` parses the generated manifest and registers the marketplace (verified locally; see Notes)
- [x] `check-codex-sync.sh` exits non-zero on injected drift, zero on a clean tree
- [x] `check-versions.sh` fails when the codex manifest version differs, passes when all six match
- [x] BATS golden-output test asserts the generated tree + manifest validity
- [x] Pre-commit hook and CI run the drift guard and the extended version check
- [x] `AGENTS.md` corrected: accurate paths, no `.Codex-plugin`, no version mislabel

## Test plan
- [ ] `bash scripts/check-versions.sh` → all six in sync at 4.8.0
- [ ] `bash scripts/check-codex-sync.sh` → in sync
- [ ] `shellcheck --severity=warning scripts/*.sh hooks/*.sh test/run.sh test/test_helper.bash` → clean
- [ ] `npm test` → 154 tests pass (incl. 5 new `build-codex` + 1 new `check-versions` codex test)
- [ ] `codex plugin marketplace add <path-to-checkout>` → enable plugin → `using-shipyard` activates in a live Codex session

## Notes for reviewer
- **Checkmarks are author claims** — verified locally (shellcheck clean, 154/154 BATS pass, version sync + drift guard green, and `codex plugin marketplace add` registered the marketplace successfully). Un-tick anything you want to re-verify.
- **`grill-me` → `using-shipyard` substitution:** issue #15 named `grill-me` as the skeleton skill, but `grill-me` is *not* a Shipyard skill (it's a personal skill that happened to be in `~/.codex/skills/`). The walking skeleton uses `using-shipyard`, Shipyard's actual entry skill. Same proof-of-pipeline; one real skill copied byte-for-byte.
- **Layout refinement:** the issue's loose phrasing put `.codex-plugin/plugin.json` at repo root; the real Codex format (per the bundled `browser-use` plugin) nests it at `plugins/shipyard/.codex-plugin/plugin.json` with the marketplace at `.agents/plugins/marketplace.json`. Implemented to match real Codex.
- **Version-sync scope:** Codex's `marketplace.json` carries no per-plugin version field (unlike Claude's), so the version guard covers the codex `plugin.json` (the canonical version location) — 6 version-bearing files total, not the PRD's nominal "two codex manifests."
- The one acceptance check that can't be auto-verified headless is a skill *running* in a live interactive Codex session. Per the loop's intent (ship so real users surface Codex issues), this is left for real-use validation.

## Out of scope
- The other 18 skills (Slice 2 / #16), orchestration + state entrypoint skills (#17, #18), and the Codex user guide (#19).
