### PR TITLE
feat(codex): orchestration entrypoint skills (inline-sequential personas)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "shipyard",
-      "version": "4.9.0",
+      "version": "4.10.0",
       "description": "Ship software systematically: project lifecycle, TDD, parallel agents, code review, security auditing, and infrastructure validation",
       "source": "./",
       "category": "development"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "description": "Ship software systematically: project lifecycle, TDD, parallel agents, code review, security auditing, and infrastructure validation",
   "author": {
     "name": "lgbarn",

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,5 +9,6 @@
 # spurious drift failure. Skill sources are byte-copied into the tree, so pin
 # them too.
 skills/**/*.md text eol=lf
+codex/skills-extra/**/*.md text eol=lf
 plugins/** text eol=lf
 .agents/** text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [4.10.0] - 2026-06-19
+
+### Added
+- **Codex orchestration entrypoint skills** (#17): Codex-only skills in `codex/skills-extra/` that bring Shipyard's multi-agent workflows to Codex as **inline sequential personas** (Codex has no parallel subagents). New skills: `shipyard-codex-orchestration` (degradation model + router), `shipyard-review`, `shipyard-research`, `shipyard-map`, `shipyard-ship`. Each carries an explicit honest-degradation note (no parallelism, no fresh-context isolation; review/verify gates preserved).
+- These fill the gap where an agent persona (reviewer, researcher, mapper) had no skill home in Codex. Commands already covered by a canonical skill (build→executing-plans, audit→security-audit, plan→writing-plans) get no duplicate skill — only the inline-sequential framing via the orchestration router.
+
+### Changed
+- **`build-codex.sh` merges two skill sources**: canonical `skills/` plus Codex-only `codex/skills-extra/`.
+
 ## [4.9.0] - 2026-06-19
 
 ### Added

--- a/codex/skills-extra/shipyard-codex-orchestration/SKILL.md
+++ b/codex/skills-extra/shipyard-codex-orchestration/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: shipyard-codex-orchestration
+description: Use when running any multi-step Shipyard workflow under Codex — build, audit, plan, ship, review, research, or map. Explains how Shipyard's parallel-agent workflows degrade to inline sequential execution in Codex, and routes intent to the right workflow skill. Trigger when the user says "build the plan", "audit this", "ship it", "review the code", "run the shipyard build", or asks how Shipyard works in Codex.
+---
+
+# Shipyard orchestration under Codex
+
+Shipyard was built for Claude Code, where workflows dispatch **fresh subagents in
+parallel** (builder, reviewer, auditor, architect, verifier, researcher, mapper, …)
+via the Task tool. Codex has no equivalent — it runs in a single context.
+
+So under Codex, Shipyard workflows run as **inline sequential personas**: instead of
+dispatching a separate agent, you adopt each role yourself, one after another, in this
+same conversation.
+
+## Honest degradation — what you lose
+
+- **No parallelism.** Roles run one at a time, so multi-agent phases are slower.
+- **No context isolation.** In Claude Code a fresh reviewer can't be biased by the
+  builder's reasoning. Here the same context does both, so a review is less independent.
+  Compensate by being deliberately skeptical when you switch into a review/verify role —
+  re-read the actual artifact, don't trust your own prior step.
+
+What you keep: the **discipline** — the review and verify gates still run, just sequentially.
+
+## The inline-sequential pattern
+
+When a workflow calls for "dispatch the X agent", instead:
+
+1. State which role you're entering ("Now acting as the reviewer…").
+2. Adopt that role's mandate fully — including its MUST-NOT constraints (a reviewer
+   makes no code edits; a mapper only documents).
+3. Produce the role's deliverable.
+4. Exit the role and continue the workflow.
+
+## Routing — which skill for which intent
+
+| Intent | Skill / behavior |
+|---|---|
+| Implement a plan | `shipyard-executing-plans` skill, run builder→reviewer→verifier inline |
+| Security/compliance audit | `security-audit` skill, adopting the auditor mandate |
+| Create a plan | `shipyard-writing-plans` skill (+ `shipyard-brainstorming` first) |
+| Code review after a build | `shipyard-review` skill |
+| Domain/technology research | `shipyard-research` skill |
+| Map/onboard a codebase | `shipyard-map` skill |
+| Ship/release a completed phase | `shipyard-ship` skill |
+| TDD a feature | `shipyard-tdd` skill |
+| Debug a failure | `shipyard-debugging` skill |
+
+If a workflow has a dedicated skill, use it and apply the inline-sequential pattern above
+to any agent dispatch it describes. The `shipyard-review`, `shipyard-research`,
+`shipyard-map`, and `shipyard-ship` skills exist because those roles have no other skill
+home in Codex.
+
+## State
+
+Codex has no SessionStart hook, so Shipyard state is not auto-loaded. When a workflow
+needs project state, run `scripts/state-read.sh` yourself at the start (see the
+state/utility skills).

--- a/codex/skills-extra/shipyard-map/SKILL.md
+++ b/codex/skills-extra/shipyard-map/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: shipyard-map
+description: Use when performing brownfield analysis on an existing codebase under Codex — onboarding to a new project, generating codebase documentation, or understanding legacy code. Trigger when the user says "map this codebase", "help me understand this code", "document this project", "I just inherited this repo", or runs shipyard init on existing code. This is the Codex inline-sequential form of the mapper agent.
+---
+
+# Mapping a codebase (Codex inline-sequential)
+
+This is the mapper role from Shipyard's `/shipyard:init` and `/shipyard:map` flows, adapted
+for Codex. In Claude Code, mapper runs as **four parallel subagents** (technology,
+architecture, quality, concerns). Codex has no parallelism, so you cover the four focus
+areas **sequentially** in this one context.
+
+You are an **analysis-only** role. You MUST NOT modify any code — you read, analyze, and
+document. Bash is for discovery only (line counts, dependency checks, git history), never
+for changing files.
+
+**Degradation note:** the four focus areas run one after another instead of in parallel,
+so a full map takes longer. The output quality is the same — only the wall-clock differs.
+
+## Focus areas (run each in turn)
+
+1. **Technology** → `STACK.md` — languages, frameworks, build tooling, dependencies.
+2. **Architecture** → `ARCHITECTURE.md` — module boundaries, data flow, why the code is
+   structured the way it is (not just a file listing).
+3. **Quality** → `TESTING.md` / `CONVENTIONS.md` — test posture, coverage gaps, conventions.
+4. **Concerns** → `CONCERNS.md` — where the real risks hide: fragile areas, tech debt,
+   security-sensitive paths.
+
+## Rules
+
+- **Cite every finding** with at least one repo-relative file path (e.g.
+  `scripts/state-read.sh`). Never assert without evidence. Never use absolute paths.
+- **Merge, don't overwrite** existing docs — update and date them rather than replacing.
+- Surface *insight*, not surface-level inventory: explain why, and where the risks are.

--- a/codex/skills-extra/shipyard-research/SKILL.md
+++ b/codex/skills-extra/shipyard-research/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: shipyard-research
+description: Use when conducting domain research, evaluating technology options, investigating ecosystem choices, or gathering knowledge for a development phase under Codex. Trigger when the user says "research X", "what are our options for", "evaluate these libraries", "what's the best approach to", or before planning a phase. This is the Codex inline-sequential form of the researcher agent.
+---
+
+# Domain research (Codex inline-sequential)
+
+This is the researcher role from Shipyard, adapted for Codex. In Claude Code a researcher
+subagent gathers domain knowledge before a plan; here you adopt the role yourself.
+
+You produce a **research document** — you do not implement anything in this role.
+
+**Degradation note:** in Claude Code this runs in a fresh context isolated from
+implementation. Here it shares context, so guard against motivated reasoning — research
+honestly about tradeoffs, do not cheerlead the option you'd find easiest to build.
+
+## Protocol
+
+1. **Understand the context.** Read existing `.shipyard/` docs (STACK.md, ARCHITECTURE.md,
+   ROADMAP.md) and the codebase conventions. Research that ignores the current stack and
+   constraints is useless. Run `scripts/state-read.sh` first if state isn't loaded.
+2. **Investigate options.** For each candidate technology/approach, gather: maturity and
+   community health, maintenance burden, fit with the existing stack, and known pitfalls.
+3. **Be honest about tradeoffs.** Technology decisions are not just feature checklists —
+   weigh maintenance, hiring, and long-term viability. Name the cost of each option, not
+   just its benefits.
+4. **Recommend.** Give a clear recommendation with reasoning, and note what would change
+   the recommendation.
+
+## Deliverable
+
+A structured research document: the question, the options compared (with tradeoffs), a
+recommendation, and open risks. Cite sources for external claims; cite repo-relative file
+paths for claims about the existing codebase.

--- a/codex/skills-extra/shipyard-review/SKILL.md
+++ b/codex/skills-extra/shipyard-review/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: shipyard-review
+description: Use when reviewing code under Codex — verifying spec compliance, conducting quality review after a build, or checking that an implementation matches its plan. Trigger when the user says "review this", "review the implementation", "does this match the plan", "check the code quality", or after a Shipyard build completes. This is the Codex inline-sequential form of the reviewer agent.
+---
+
+# Reviewing code (Codex inline-sequential)
+
+This is the reviewer role from Shipyard's `/shipyard:build` flow, adapted for Codex. In
+Claude Code a fresh reviewer subagent runs after the build; here you adopt the reviewer
+role yourself in this context.
+
+**Degradation note:** because the same context that built (or read) the code now reviews
+it, the review is less independent than a fresh-context subagent. Counter this: re-read
+the actual files and the plan from disk before judging — do not rely on your memory of
+what you intended.
+
+You are a **review-only** role. You MUST NOT edit code, run builds, or change state. You
+produce findings only.
+
+## Two-stage review
+
+### Stage 1 — Spec compliance
+Compare the implementation against its `PLAN.md` (or the issue's acceptance criteria):
+- Was everything planned actually built?
+- Was anything added that wasn't planned (scope creep)?
+- Do the acceptance criteria each hold when you trace the real code path?
+
+**If Stage 1 fails, stop and report. Do not proceed to Stage 2** — the deviations must be
+fixed first.
+
+### Stage 2 — Quality
+Only after Stage 1 passes. Assess correctness, security, error handling, and clarity.
+
+## Findings format
+
+Every finding is specific and actionable: `path:line`, what's wrong, why it matters, and
+the remediation. Vague feedback ("could be improved") is not allowed. Classify severity:
+
+- **Critical** — must fix before merge: security holes, broken functionality, data loss,
+  failing tests.
+- **Major** — significant design/maintainability problems.
+- **Minor / Nit** — smaller issues, polish.
+
+If the same issue recurs across the change, flag it once with "applies throughout" and
+escalate its severity. End with a one-line verdict: blocked / needs-work / ship-ready.

--- a/codex/skills-extra/shipyard-ship/SKILL.md
+++ b/codex/skills-extra/shipyard-ship/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: shipyard-ship
+description: Use when delivering or releasing a completed Shipyard phase under Codex — final verification, pre-ship security audit, documentation, and release. Trigger when the user says "ship it", "ship this phase", "release this", "we're done — finalize", or "run the shipyard ship workflow". This is the Codex inline-sequential form of the /shipyard:ship orchestration.
+---
+
+# Shipping a phase (Codex inline-sequential)
+
+This is Shipyard's `/shipyard:ship` delivery flow, adapted for Codex. The flow is already
+sequential (verify → audit → document → deliver), so it maps cleanly to a single context —
+you adopt each role in turn rather than dispatching subagents.
+
+**Degradation note:** the audit and documentation steps run as inline personas, not
+fresh-context subagents. Be deliberately thorough on the audit step — shipping is the
+final gate, so do not let earlier context make you assume the code is fine.
+
+Run `scripts/state-read.sh` first if state isn't loaded.
+
+## Steps (run each in order; stop on a hard failure)
+
+1. **Pre-ship verification.** Use the `shipyard-verification` skill to confirm success
+   criteria are met and the phase is actually complete.
+2. **Run the test suite.** All tests must pass. A failure here blocks the ship.
+3. **Pre-ship security audit.** Adopt the auditor mandate (OWASP Top 10, secrets, dependency
+   vulnerabilities). Shipping is the final security gate — this runs even if the build skipped
+   auditing. If a passing audit already exists and nothing changed since, verify it has no
+   unresolved critical findings instead of re-auditing. **Any unresolved critical finding
+   blocks the ship.**
+4. **Documentation.** Adopt the documenter mandate — generate/refresh API, architecture, and
+   user-facing docs in `docs/`. If up-to-date docs already exist from the build, verify
+   completeness instead of regenerating.
+5. **Capture lessons.** Use the `lessons-learned` skill to record what was learned this phase.
+6. **Deliver.** Finalize per the project's release convention (version bump, CHANGELOG, tag,
+   PR/merge). Never auto-merge without the user's go-ahead unless they've authorized it.
+
+## Done means
+
+Verification passed, tests green, no unresolved critical audit findings, docs complete,
+lessons captured, and the release artifact prepared. Report the status of each gate
+explicitly — do not claim "shipped" if any gate was skipped.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lgbarn/shipyard",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lgbarn/shipyard",
-      "version": "4.9.0",
+      "version": "4.10.0",
       "license": "MIT",
       "devDependencies": {
         "bats": "^1.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lgbarn/shipyard",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "description": "Ship software systematically: project lifecycle, TDD, parallel agents, code review, security auditing, and infrastructure validation — from idea to production",
   "keywords": [
     "claude-code-plugin",

--- a/plugins/shipyard/.codex-plugin/plugin.json
+++ b/plugins/shipyard/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "description": "Ship software systematically: project lifecycle, TDD, parallel agents, code review, security auditing, and infrastructure validation",
   "author": {
     "name": "lgbarn",

--- a/plugins/shipyard/skills/shipyard-codex-orchestration/SKILL.md
+++ b/plugins/shipyard/skills/shipyard-codex-orchestration/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: shipyard-codex-orchestration
+description: Use when running any multi-step Shipyard workflow under Codex — build, audit, plan, ship, review, research, or map. Explains how Shipyard's parallel-agent workflows degrade to inline sequential execution in Codex, and routes intent to the right workflow skill. Trigger when the user says "build the plan", "audit this", "ship it", "review the code", "run the shipyard build", or asks how Shipyard works in Codex.
+---
+
+# Shipyard orchestration under Codex
+
+Shipyard was built for Claude Code, where workflows dispatch **fresh subagents in
+parallel** (builder, reviewer, auditor, architect, verifier, researcher, mapper, …)
+via the Task tool. Codex has no equivalent — it runs in a single context.
+
+So under Codex, Shipyard workflows run as **inline sequential personas**: instead of
+dispatching a separate agent, you adopt each role yourself, one after another, in this
+same conversation.
+
+## Honest degradation — what you lose
+
+- **No parallelism.** Roles run one at a time, so multi-agent phases are slower.
+- **No context isolation.** In Claude Code a fresh reviewer can't be biased by the
+  builder's reasoning. Here the same context does both, so a review is less independent.
+  Compensate by being deliberately skeptical when you switch into a review/verify role —
+  re-read the actual artifact, don't trust your own prior step.
+
+What you keep: the **discipline** — the review and verify gates still run, just sequentially.
+
+## The inline-sequential pattern
+
+When a workflow calls for "dispatch the X agent", instead:
+
+1. State which role you're entering ("Now acting as the reviewer…").
+2. Adopt that role's mandate fully — including its MUST-NOT constraints (a reviewer
+   makes no code edits; a mapper only documents).
+3. Produce the role's deliverable.
+4. Exit the role and continue the workflow.
+
+## Routing — which skill for which intent
+
+| Intent | Skill / behavior |
+|---|---|
+| Implement a plan | `shipyard-executing-plans` skill, run builder→reviewer→verifier inline |
+| Security/compliance audit | `security-audit` skill, adopting the auditor mandate |
+| Create a plan | `shipyard-writing-plans` skill (+ `shipyard-brainstorming` first) |
+| Code review after a build | `shipyard-review` skill |
+| Domain/technology research | `shipyard-research` skill |
+| Map/onboard a codebase | `shipyard-map` skill |
+| Ship/release a completed phase | `shipyard-ship` skill |
+| TDD a feature | `shipyard-tdd` skill |
+| Debug a failure | `shipyard-debugging` skill |
+
+If a workflow has a dedicated skill, use it and apply the inline-sequential pattern above
+to any agent dispatch it describes. The `shipyard-review`, `shipyard-research`,
+`shipyard-map`, and `shipyard-ship` skills exist because those roles have no other skill
+home in Codex.
+
+## State
+
+Codex has no SessionStart hook, so Shipyard state is not auto-loaded. When a workflow
+needs project state, run `scripts/state-read.sh` yourself at the start (see the
+state/utility skills).

--- a/plugins/shipyard/skills/shipyard-map/SKILL.md
+++ b/plugins/shipyard/skills/shipyard-map/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: shipyard-map
+description: Use when performing brownfield analysis on an existing codebase under Codex — onboarding to a new project, generating codebase documentation, or understanding legacy code. Trigger when the user says "map this codebase", "help me understand this code", "document this project", "I just inherited this repo", or runs shipyard init on existing code. This is the Codex inline-sequential form of the mapper agent.
+---
+
+# Mapping a codebase (Codex inline-sequential)
+
+This is the mapper role from Shipyard's `/shipyard:init` and `/shipyard:map` flows, adapted
+for Codex. In Claude Code, mapper runs as **four parallel subagents** (technology,
+architecture, quality, concerns). Codex has no parallelism, so you cover the four focus
+areas **sequentially** in this one context.
+
+You are an **analysis-only** role. You MUST NOT modify any code — you read, analyze, and
+document. Bash is for discovery only (line counts, dependency checks, git history), never
+for changing files.
+
+**Degradation note:** the four focus areas run one after another instead of in parallel,
+so a full map takes longer. The output quality is the same — only the wall-clock differs.
+
+## Focus areas (run each in turn)
+
+1. **Technology** → `STACK.md` — languages, frameworks, build tooling, dependencies.
+2. **Architecture** → `ARCHITECTURE.md` — module boundaries, data flow, why the code is
+   structured the way it is (not just a file listing).
+3. **Quality** → `TESTING.md` / `CONVENTIONS.md` — test posture, coverage gaps, conventions.
+4. **Concerns** → `CONCERNS.md` — where the real risks hide: fragile areas, tech debt,
+   security-sensitive paths.
+
+## Rules
+
+- **Cite every finding** with at least one repo-relative file path (e.g.
+  `scripts/state-read.sh`). Never assert without evidence. Never use absolute paths.
+- **Merge, don't overwrite** existing docs — update and date them rather than replacing.
+- Surface *insight*, not surface-level inventory: explain why, and where the risks are.

--- a/plugins/shipyard/skills/shipyard-research/SKILL.md
+++ b/plugins/shipyard/skills/shipyard-research/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: shipyard-research
+description: Use when conducting domain research, evaluating technology options, investigating ecosystem choices, or gathering knowledge for a development phase under Codex. Trigger when the user says "research X", "what are our options for", "evaluate these libraries", "what's the best approach to", or before planning a phase. This is the Codex inline-sequential form of the researcher agent.
+---
+
+# Domain research (Codex inline-sequential)
+
+This is the researcher role from Shipyard, adapted for Codex. In Claude Code a researcher
+subagent gathers domain knowledge before a plan; here you adopt the role yourself.
+
+You produce a **research document** — you do not implement anything in this role.
+
+**Degradation note:** in Claude Code this runs in a fresh context isolated from
+implementation. Here it shares context, so guard against motivated reasoning — research
+honestly about tradeoffs, do not cheerlead the option you'd find easiest to build.
+
+## Protocol
+
+1. **Understand the context.** Read existing `.shipyard/` docs (STACK.md, ARCHITECTURE.md,
+   ROADMAP.md) and the codebase conventions. Research that ignores the current stack and
+   constraints is useless. Run `scripts/state-read.sh` first if state isn't loaded.
+2. **Investigate options.** For each candidate technology/approach, gather: maturity and
+   community health, maintenance burden, fit with the existing stack, and known pitfalls.
+3. **Be honest about tradeoffs.** Technology decisions are not just feature checklists —
+   weigh maintenance, hiring, and long-term viability. Name the cost of each option, not
+   just its benefits.
+4. **Recommend.** Give a clear recommendation with reasoning, and note what would change
+   the recommendation.
+
+## Deliverable
+
+A structured research document: the question, the options compared (with tradeoffs), a
+recommendation, and open risks. Cite sources for external claims; cite repo-relative file
+paths for claims about the existing codebase.

--- a/plugins/shipyard/skills/shipyard-review/SKILL.md
+++ b/plugins/shipyard/skills/shipyard-review/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: shipyard-review
+description: Use when reviewing code under Codex — verifying spec compliance, conducting quality review after a build, or checking that an implementation matches its plan. Trigger when the user says "review this", "review the implementation", "does this match the plan", "check the code quality", or after a Shipyard build completes. This is the Codex inline-sequential form of the reviewer agent.
+---
+
+# Reviewing code (Codex inline-sequential)
+
+This is the reviewer role from Shipyard's `/shipyard:build` flow, adapted for Codex. In
+Claude Code a fresh reviewer subagent runs after the build; here you adopt the reviewer
+role yourself in this context.
+
+**Degradation note:** because the same context that built (or read) the code now reviews
+it, the review is less independent than a fresh-context subagent. Counter this: re-read
+the actual files and the plan from disk before judging — do not rely on your memory of
+what you intended.
+
+You are a **review-only** role. You MUST NOT edit code, run builds, or change state. You
+produce findings only.
+
+## Two-stage review
+
+### Stage 1 — Spec compliance
+Compare the implementation against its `PLAN.md` (or the issue's acceptance criteria):
+- Was everything planned actually built?
+- Was anything added that wasn't planned (scope creep)?
+- Do the acceptance criteria each hold when you trace the real code path?
+
+**If Stage 1 fails, stop and report. Do not proceed to Stage 2** — the deviations must be
+fixed first.
+
+### Stage 2 — Quality
+Only after Stage 1 passes. Assess correctness, security, error handling, and clarity.
+
+## Findings format
+
+Every finding is specific and actionable: `path:line`, what's wrong, why it matters, and
+the remediation. Vague feedback ("could be improved") is not allowed. Classify severity:
+
+- **Critical** — must fix before merge: security holes, broken functionality, data loss,
+  failing tests.
+- **Major** — significant design/maintainability problems.
+- **Minor / Nit** — smaller issues, polish.
+
+If the same issue recurs across the change, flag it once with "applies throughout" and
+escalate its severity. End with a one-line verdict: blocked / needs-work / ship-ready.

--- a/plugins/shipyard/skills/shipyard-ship/SKILL.md
+++ b/plugins/shipyard/skills/shipyard-ship/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: shipyard-ship
+description: Use when delivering or releasing a completed Shipyard phase under Codex — final verification, pre-ship security audit, documentation, and release. Trigger when the user says "ship it", "ship this phase", "release this", "we're done — finalize", or "run the shipyard ship workflow". This is the Codex inline-sequential form of the /shipyard:ship orchestration.
+---
+
+# Shipping a phase (Codex inline-sequential)
+
+This is Shipyard's `/shipyard:ship` delivery flow, adapted for Codex. The flow is already
+sequential (verify → audit → document → deliver), so it maps cleanly to a single context —
+you adopt each role in turn rather than dispatching subagents.
+
+**Degradation note:** the audit and documentation steps run as inline personas, not
+fresh-context subagents. Be deliberately thorough on the audit step — shipping is the
+final gate, so do not let earlier context make you assume the code is fine.
+
+Run `scripts/state-read.sh` first if state isn't loaded.
+
+## Steps (run each in order; stop on a hard failure)
+
+1. **Pre-ship verification.** Use the `shipyard-verification` skill to confirm success
+   criteria are met and the phase is actually complete.
+2. **Run the test suite.** All tests must pass. A failure here blocks the ship.
+3. **Pre-ship security audit.** Adopt the auditor mandate (OWASP Top 10, secrets, dependency
+   vulnerabilities). Shipping is the final security gate — this runs even if the build skipped
+   auditing. If a passing audit already exists and nothing changed since, verify it has no
+   unresolved critical findings instead of re-auditing. **Any unresolved critical finding
+   blocks the ship.**
+4. **Documentation.** Adopt the documenter mandate — generate/refresh API, architecture, and
+   user-facing docs in `docs/`. If up-to-date docs already exist from the build, verify
+   completeness instead of regenerating.
+5. **Capture lessons.** Use the `lessons-learned` skill to record what was learned this phase.
+6. **Deliver.** Finalize per the project's release convention (version bump, CHANGELOG, tag,
+   PR/merge). Never auto-merge without the user's go-ahead unless they've authorized it.
+
+## Done means
+
+Verification passed, tests green, no unresolved critical audit findings, docs complete,
+lessons captured, and the release artifact prepared. Report the status of each gate
+explicitly — do not claim "shipped" if any gate was skipped.

--- a/scripts/build-codex.sh
+++ b/scripts/build-codex.sh
@@ -66,18 +66,23 @@ jq -n --arg name "${NAME}" '{
       ]
     }' > "${MARKETPLACE}"
 
-# --- copy every canonical skill byte-for-byte (Codex SKILL.md format is identical) ---
+# --- copy skills byte-for-byte (Codex SKILL.md format is identical) ---
+# Sources: the canonical shared skills, plus Codex-only entrypoint skills that
+# exist because Codex has no slash commands / parallel subagents (codex/skills-extra).
 skill_count=0
-for src in "${ROOT_DIR}"/skills/*/; do
-    [[ -f "${src}SKILL.md" ]] || continue
-    name="$(basename "${src}")"
-    mkdir -p "${PLUGIN_DIR}/skills/${name}"
-    cp "${src}SKILL.md" "${PLUGIN_DIR}/skills/${name}/SKILL.md"
-    skill_count=$((skill_count + 1))
+for skills_root in "${ROOT_DIR}/skills" "${ROOT_DIR}/codex/skills-extra"; do
+    [[ -d "${skills_root}" ]] || continue
+    for src in "${skills_root}"/*/; do
+        [[ -f "${src}SKILL.md" ]] || continue
+        name="$(basename "${src}")"
+        mkdir -p "${PLUGIN_DIR}/skills/${name}"
+        cp "${src}SKILL.md" "${PLUGIN_DIR}/skills/${name}/SKILL.md"
+        skill_count=$((skill_count + 1))
+    done
 done
 
 if [[ ${skill_count} -eq 0 ]]; then
-    echo "Error: no canonical skills found under ${ROOT_DIR}/skills" >&2
+    echo "Error: no skills found under ${ROOT_DIR}/skills or ${ROOT_DIR}/codex/skills-extra" >&2
     exit 1
 fi
 

--- a/test/build-codex.bats
+++ b/test/build-codex.bats
@@ -45,17 +45,31 @@ CHECK_SYNC="${PROJECT_ROOT}/scripts/check-codex-sync.sh"
 @test "build-codex: emits every canonical skill, byte-for-byte" {
     bash "$BUILD_CODEX" "${BATS_TEST_TMPDIR}"
 
+    # the tree contains the canonical skills plus any Codex-only entrypoint skills,
+    # so it has at least as many skills as skills/ — every canonical one byte-identical.
     local src_count gen_count
     src_count=$(find "${PROJECT_ROOT}/skills" -mindepth 2 -maxdepth 2 -name SKILL.md | wc -l)
     gen_count=$(find "${BATS_TEST_TMPDIR}/plugins/shipyard/skills" -mindepth 2 -maxdepth 2 -name SKILL.md | wc -l)
-    [ "$src_count" -eq "$gen_count" ]
-    [ "$gen_count" -gt 1 ]
+    [ "$gen_count" -ge "$src_count" ]
+    [ "$src_count" -gt 1 ]
 
     # every canonical skill is present and identical in the generated tree
     for src in "${PROJECT_ROOT}"/skills/*/SKILL.md; do
         local name
         name="$(basename "$(dirname "$src")")"
         diff "$src" "${BATS_TEST_TMPDIR}/plugins/shipyard/skills/${name}/SKILL.md"
+    done
+}
+
+# bats test_tags=unit
+@test "build-codex: merges Codex-only entrypoint skills from codex/skills-extra" {
+    bash "$BUILD_CODEX" "${BATS_TEST_TMPDIR}"
+    for extra in "${PROJECT_ROOT}"/codex/skills-extra/*/; do
+        [ -f "${extra}SKILL.md" ] || continue
+        local name
+        name="$(basename "${extra}")"
+        [ -f "${BATS_TEST_TMPDIR}/plugins/shipyard/skills/${name}/SKILL.md" ]
+        diff "${extra}SKILL.md" "${BATS_TEST_TMPDIR}/plugins/shipyard/skills/${name}/SKILL.md"
     done
 }
 


### PR DESCRIPTION
## Summary
- Slice 3 of Codex support (PRD #14): brings Shipyard's multi-agent workflows to Codex as **inline sequential personas**, since Codex has no parallel subagents.
- New Codex-only skills in `codex/skills-extra/` (merged into the tree by the generator): `shipyard-codex-orchestration` (degradation model + intent router), `shipyard-review`, `shipyard-research`, `shipyard-map`, `shipyard-ship`.
- These fill the gap where an agent persona (reviewer/researcher/mapper) had **no skill home** in Codex. Commands already covered by a canonical skill (build→executing-plans, audit→security-audit, plan→writing-plans) get **no duplicate** — only the inline-sequential framing via the router.

## Closes
Closes #17

## Acceptance criteria
- [x] Coverage mapping recorded (see commit body + summary): build/audit/plan have skill homes → no new skill; review/research/map/ship had none → new entrypoint skills
- [x] Entrypoint skills exist in `codex/skills-extra/` and are merged into the tree by the generator (24 skills total)
- [x] Each orchestration skill describes the inline-sequential persona sequence + an explicit degradation note
- [x] `shipyard-codex-orchestration` routes intent to the right skill/persona
- [x] Golden test + drift guard updated and passing for the merged tree
- [x] No double-maintenance: skill-covered commands get no new entrypoint skill

## Test plan
- [ ] `npm test` → 156 pass (incl. new "merges Codex-only entrypoint skills" test)
- [ ] `bash scripts/check-codex-sync.sh` → in sync; `bash scripts/check-versions.sh` → 6 files at 4.10.0
- [ ] In a live Codex session, an orchestration workflow (e.g. review or ship) runs end-to-end with gates executing sequentially

## Notes for reviewer
- This is the judgment-heaviest slice. The persona bodies are distilled from `agents/reviewer.md`, `agents/researcher.md`, `agents/mapper.md`, and the `/shipyard:ship` command — adapted for single-context inline-sequential execution with honest degradation notes.
- Checkmarks verified locally (156/156 BATS, shellcheck clean, drift + version guards green). The live-Codex end-to-end run is left for real-use surfacing.
- Name collisions between `skills/` and `codex/skills-extra/` would let the latter overwrite the former on copy; the new names are clearly namespaced (`shipyard-review` etc.), so no collision exists today.

## Out of scope
- State/utility entrypoint skills (#18) and the Codex user guide (#19).