### PR TITLE
feat(codex): state/utility entrypoint skill (on-demand state)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "shipyard",
-      "version": "4.10.0",
+      "version": "4.11.0",
       "description": "Ship software systematically: project lifecycle, TDD, parallel agents, code review, security auditing, and infrastructure validation",
       "source": "./",
       "category": "development"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "Ship software systematically: project lifecycle, TDD, parallel agents, code review, security auditing, and infrastructure validation",
   "author": {
     "name": "lgbarn",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [4.11.0] - 2026-06-19
+
+### Added
+- **Codex state/utility entrypoint skill** (#18): `shipyard-state` brings Shipyard's state lifecycle (status, resume, cancel, rollback) to Codex. Because Codex has no `SessionStart` hook, the skill loads state **on demand** by invoking the bundled bash scripts (`state-read.sh`, `state-write.sh`, `checkpoint.sh`) rather than relying on auto-injection. Full state fidelity is retained; the teammate lifecycle hooks intentionally do not port (moot in single-context Codex).
+
 ## [4.10.0] - 2026-06-19
 
 ### Added

--- a/codex/skills-extra/shipyard-state/SKILL.md
+++ b/codex/skills-extra/shipyard-state/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: shipyard-state
+description: Use to inspect or manage Shipyard project state under Codex — show status, resume a previous session, cancel/pause in-progress work, or roll back to a checkpoint. Trigger when the user says "shipyard status", "what's the status", "resume", "continue where we left off", "cancel", "pause this", "roll back", or "restore the checkpoint". Codex has no SessionStart hook, so this skill loads state on demand.
+---
+
+# Shipyard state (Codex on-demand)
+
+In Claude Code, Shipyard's `SessionStart` hook auto-injects project state at the start of
+every session. **Codex has no such hook**, so state is not loaded automatically — you must
+read it on demand with the bundled scripts before acting. All state lives under `.shipyard/`
+(STATE.json, HISTORY.md, ROADMAP.md, PROJECT.md, config.json).
+
+Always run the read step first; if `.shipyard/STATE.json` is absent, tell the user there is
+no Shipyard project here (suggest `shipyard init`) instead of inventing state.
+
+## Status — show the dashboard
+
+```bash
+bash scripts/state-read.sh        # prints JSON context (current phase, position, status)
+```
+
+Then also read `.shipyard/HISTORY.md` and `ROADMAP.md` for the fuller picture, and present a
+clear dashboard: current phase, position, status, and recent history.
+
+## Resume — restore context and continue
+
+```bash
+bash scripts/state-read.sh
+```
+
+Read STATE.json for the current phase/position/status and HISTORY.md for what happened, then
+continue the workflow from there. If no state exists, there is nothing to resume.
+
+## Cancel — graceful pause
+
+Checkpoint first, then mark the work paused so it can be resumed later:
+
+```bash
+bash scripts/checkpoint.sh "pre-cancel-$(date +%s)"   # git tag rollback point
+bash scripts/state-write.sh --phase <N> --position "<where you stopped>" --status paused
+```
+
+Only cancel work that is actually in progress (`building`/`in_progress`/`planning`). If it is
+already paused or complete, say so rather than writing redundant state.
+
+## Roll back — restore a checkpoint
+
+Checkpoints are git tags created by `checkpoint.sh`. List them and revert with git:
+
+```bash
+git tag -l 'shipyard-*'                # or however the project tags checkpoints
+git checkout <checkpoint-tag>          # inspect, or reset per the user's intent
+```
+
+This is a destructive git operation — confirm with the user before resetting, and never
+force-reset their working tree without explicit instruction.
+
+## Degradation note
+
+Everything here works identically to Claude Code except that state is pulled on demand
+instead of auto-injected. The teammate lifecycle hooks (idle/task-completed/stop) do not
+exist in Codex — that is expected, not a regression, because Codex runs single-context.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lgbarn/shipyard",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lgbarn/shipyard",
-      "version": "4.10.0",
+      "version": "4.11.0",
       "license": "MIT",
       "devDependencies": {
         "bats": "^1.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lgbarn/shipyard",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "Ship software systematically: project lifecycle, TDD, parallel agents, code review, security auditing, and infrastructure validation — from idea to production",
   "keywords": [
     "claude-code-plugin",

--- a/plugins/shipyard/.codex-plugin/plugin.json
+++ b/plugins/shipyard/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shipyard",
-  "version": "4.10.0",
+  "version": "4.11.0",
   "description": "Ship software systematically: project lifecycle, TDD, parallel agents, code review, security auditing, and infrastructure validation",
   "author": {
     "name": "lgbarn",

--- a/plugins/shipyard/skills/shipyard-state/SKILL.md
+++ b/plugins/shipyard/skills/shipyard-state/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: shipyard-state
+description: Use to inspect or manage Shipyard project state under Codex — show status, resume a previous session, cancel/pause in-progress work, or roll back to a checkpoint. Trigger when the user says "shipyard status", "what's the status", "resume", "continue where we left off", "cancel", "pause this", "roll back", or "restore the checkpoint". Codex has no SessionStart hook, so this skill loads state on demand.
+---
+
+# Shipyard state (Codex on-demand)
+
+In Claude Code, Shipyard's `SessionStart` hook auto-injects project state at the start of
+every session. **Codex has no such hook**, so state is not loaded automatically — you must
+read it on demand with the bundled scripts before acting. All state lives under `.shipyard/`
+(STATE.json, HISTORY.md, ROADMAP.md, PROJECT.md, config.json).
+
+Always run the read step first; if `.shipyard/STATE.json` is absent, tell the user there is
+no Shipyard project here (suggest `shipyard init`) instead of inventing state.
+
+## Status — show the dashboard
+
+```bash
+bash scripts/state-read.sh        # prints JSON context (current phase, position, status)
+```
+
+Then also read `.shipyard/HISTORY.md` and `ROADMAP.md` for the fuller picture, and present a
+clear dashboard: current phase, position, status, and recent history.
+
+## Resume — restore context and continue
+
+```bash
+bash scripts/state-read.sh
+```
+
+Read STATE.json for the current phase/position/status and HISTORY.md for what happened, then
+continue the workflow from there. If no state exists, there is nothing to resume.
+
+## Cancel — graceful pause
+
+Checkpoint first, then mark the work paused so it can be resumed later:
+
+```bash
+bash scripts/checkpoint.sh "pre-cancel-$(date +%s)"   # git tag rollback point
+bash scripts/state-write.sh --phase <N> --position "<where you stopped>" --status paused
+```
+
+Only cancel work that is actually in progress (`building`/`in_progress`/`planning`). If it is
+already paused or complete, say so rather than writing redundant state.
+
+## Roll back — restore a checkpoint
+
+Checkpoints are git tags created by `checkpoint.sh`. List them and revert with git:
+
+```bash
+git tag -l 'shipyard-*'                # or however the project tags checkpoints
+git checkout <checkpoint-tag>          # inspect, or reset per the user's intent
+```
+
+This is a destructive git operation — confirm with the user before resetting, and never
+force-reset their working tree without explicit instruction.
+
+## Degradation note
+
+Everything here works identically to Claude Code except that state is pulled on demand
+instead of auto-injected. The teammate lifecycle hooks (idle/task-completed/stop) do not
+exist in Codex — that is expected, not a regression, because Codex runs single-context.


### PR DESCRIPTION
## Summary
- Slice 4 of Codex support (PRD #14): `shipyard-state` brings the state lifecycle (status, resume, cancel, rollback) to Codex.
- Codex has no `SessionStart` hook, so the skill loads `.shipyard/` state **on demand** via the bundled bash scripts (`state-read.sh`, `state-write.sh`, `checkpoint.sh`) — full fidelity, just pulled instead of auto-injected.
- One consolidated skill (not 11 tiny per-command ones) keeps the surface tight while triggering on all the relevant intents.

## Closes
Closes #18

## Acceptance criteria
- [x] Entrypoint skill exists in `codex/skills-extra/` and is merged into the tree (25 skills total)
- [x] The skill runs the correct bash state script on demand (no SessionStart reliance)
- [x] status / resume / cancel / rollback are covered against `.shipyard/` state
- [x] Golden test + drift guard pass for the merged tree
- [x] No double-maintenance: no duplicate of any canonical skill (e.g. handoff keeps its skill)

## Test plan
- [ ] `npm test` → 156 pass (generic entrypoint-merge test covers `shipyard-state`)
- [ ] `bash scripts/check-codex-sync.sh` → in sync; `check-versions.sh` → 6 files at 4.11.0
- [ ] In a live Codex session, `state-read.sh` loads state and status/resume/cancel work

## Notes for reviewer
- Script invocations in the skill match the real signatures (`state-write.sh --phase/--position/--status`, `checkpoint.sh <label>`).
- Rollback explicitly flags the destructive git step and requires user confirmation — no force-reset.

## Out of scope
- Codex user guide (#19).